### PR TITLE
contrib: planb-sync: Add Minio/S3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ The following data transfer methods are supported:
   <./contrib/planb-zfssync.sh>`_);
 * snapshots of ZFS volumes (through `planb-zfssync
   <./contrib/planb-zfssync.sh>`_);
-* copies of (large) *OpenStack Swift* containers (through `planb-swiftsync
-  <./contrib/planb-swiftsync.py>`_);
+* copies of (large) *S3* and *OpenStack Swift* containers (through
+  `planb-objsync <./contrib/planb-objsync.py>`_);
 * custom transfer (through your own custom ``transfer_exec`` script).
 
 
@@ -109,12 +109,12 @@ TODO
   they have already been backed up once. The rsync job would need some
   way to keep track of changes in include/exclude settings, and run a
   cleanup in case they are changed. (See metadata storage like
-  planb-swiftsync.* files.)
+  planb-objsync.* files.)
 * RFE: Standardize stdout/stderr output from Rsync/Exec success (and
   prepend "> " to output) to be more in line with failure.
 * RFE: Add possibility to feed back snapshot size from the individual
-  Transport instead of using dutree. Parsing the swiftsync listings is
-  fast after all.
+  Transport instead of using dutree. Parsing the planb-objsync listings
+  is fast after all.
 * FIX: Add uwsgi-uid==djangoq-uid check?
 * Replace the exception mails for common errors (like failing rsync) to
   use mail_admins style mail.

--- a/contrib/planb-objsync.conf
+++ b/contrib/planb-objsync.conf
@@ -1,4 +1,4 @@
-[SECTION]
+[SWIFT_CLIENT]
 type = swift
 user = USER:USER
 key = SOMEKEY
@@ -25,5 +25,20 @@ planb_translate_2 = *=/$=%2F
 ; Dynamic Large Objects (DLO) or Static Large Objects (SLO). If
 ; auto-detection fails, you can set this:
 ;planb_container_has_segments = always
+
+; The location of the CA bundle to verify the server certificates.
+; When set to "false" the certificate verification is disabled.
+; Defaults to "true" and will use the client library default CA bundle.
+; planb_ca_cert = /path/to/my-ca-bundle.crt
+
+[S3_CLIENT]
+type = s3
+provider = Minio
+access_key_id = USER
+secret_access_key = SECRET_KEY
+endpoint = https://MINIOSERVER
+
+; The planb exclude/translate options apply to s3 storage too.
+; planb_container_has_segments has no function on on s3 object storage.
 
 ; vim: set syn=dosini:

--- a/planb/tasks.py
+++ b/planb/tasks.py
@@ -618,15 +618,18 @@ class FilesetRunner:
                 setproctitle('[backing up %d: %s]: dutree' % (
                     fileset.pk, fileset.friendly_name))
 
-                # NOTE: PlanB SwiftSync produces planb-swiftsync.cur file
+                # NOTE: PlanB ObjSync produces the planb-objsync.cur file
                 # listings which we can read _way_ faster than traversing the
                 # filesystem.  Use those if available.
-                swiftsync_path = os.path.join(
-                    path, '..', 'planb-swiftsync.cur')
-                if os.path.isfile(swiftsync_path):
-                    # Prefix with 'path'. We strip it below.
-                    duscan = PlanbSwiftSyncDuScan(
-                        swiftsync_path, root_name=path)
+                # Note: planb-swiftsync.cur was the old name of this file.
+                for objsync_name in (
+                        'planb-objsync.cur', 'planb-swiftsync.cur'):
+                    objsync_path = os.path.join(path, '..', objsync_name)
+                    if os.path.isfile(objsync_path):
+                        # Prefix with 'path'. We strip it below.
+                        duscan = PlanbSwiftSyncDuScan(
+                            objsync_path, root_name=path)
+                        break
                 else:
                     duscan = Scanner(path)
 


### PR DESCRIPTION
Allow S3 object stores (minio) to sync to planb using the boto3 client.

The object store type specific code has been refactored in the clients:
- S3SyncClient + S3ObjectLine
- SwiftSyncClient + SwiftObjectLine

The remaining Sync classes are mostly object store agnostic.

S3 does not have a segment container for dynamic large objects like swift. But does support multipart uploads which have the part count in the ETag header. S3 objects uploaded with multipart are marked as `is_dynamic_large_object` to skip the Etag check.

The script has been renamed to `contrib/planb-sync.py` to remove the "only for swift" predication.