### PR TITLE
contrib: planb-objsync: Configurable timeouts + defaults

### DIFF
--- a/contrib/planb-objsync.conf
+++ b/contrib/planb-objsync.conf
@@ -29,7 +29,16 @@ planb_translate_2 = *=/$=%2F
 ; The location of the CA bundle to verify the server certificates.
 ; When set to "false" the certificate verification is disabled.
 ; Defaults to "true" and will use the client library default CA bundle.
-; planb_ca_cert = /path/to/my-ca-bundle.crt
+;planb_ca_cert = /path/to/my-ca-bundle.crt
+
+; The connect/read timeout (int/float)
+; A single value is applied to both the connect and read timeout.
+; The S3 client can set the connect and read timeout separately with
+; comma separated values. The Swift client does not suport this and the
+; connect timeout is used for both.
+;planb_timeout = 60  ; 60s connect and read timeout (default)
+;planb_timeout = 10, 30 ; 10s connect and 30s read timeout.
+
 
 [S3_CLIENT]
 type = s3


### PR DESCRIPTION
Add the `planb_timeout` configuration option with a default of 60 seconds for all clients. The 60s default is adopted from the boto3 client because the Swift client default is to never timeout.

Note that both clients will retry failed requests.

For the boto3 client the connect and read timeout can be set separately. The Swift client does not support this because keystoneclient does not while the requests backend it uses does.

https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
https://docs.openstack.org/python-swiftclient/newton/swiftclient.html#swiftclient.client.Connection
https://docs.openstack.org/python-keystoneclient/latest/api/keystoneclient.v3.html#module-keystoneclient.v3.client
https://requests.readthedocs.io/en/latest/user/advanced/#timeouts