### PR TITLE
contrib: manual-zfssync/planb-double-backup ssh multiplexing

### DIFF
--- a/contrib/manual-zfssync.sh
+++ b/contrib/manual-zfssync.sh
@@ -11,7 +11,11 @@
 # - MANUAL_ZFSSYNC_OVERWRITE_NEWER_SNAPSHOTS=1
 
 ssh_target="$1"; shift  # remotebackup@DEST
-REMOTE_CMD="/usr/bin/ssh -oLogLevel=error $ssh_target"  # options?
+REMOTE_CMD_OPTIONS=
+if test -n "${SSH_CONTROL_PATH:-}"; then
+    REMOTE_CMD_OPTIONS="-oControlMaster=no -oControlPath=$SSH_CONTROL_PATH "
+fi
+REMOTE_CMD="/usr/bin/ssh -oLogLevel=error ${REMOTE_CMD_OPTIONS}${ssh_target}"
 
 LOCAL_PREFIX="$1"; shift  # "tank" both local and remote
 REMOTE_PREFIX="$LOCAL_PREFIX"

--- a/contrib/planb-double-backup
+++ b/contrib/planb-double-backup
@@ -18,14 +18,23 @@ SSH_CONTROL_PATH="$SSH_MUX_DIR/ctl"
 export SSH_CONTROL_PATH
 
 start_master() {
-    ssh -oLogLevel=error -oControlMaster=yes -oControlPath="$SSH_CONTROL_PATH" \
+    ssh -oLogLevel=error -oControlMaster=yes \
+        -oControlPath="$SSH_CONTROL_PATH" \
         -oControlPersist=60 -oServerAliveInterval=60 -oServerAliveCountMax=3 \
         -oBatchMode=yes -N -f "$USERATHOST"
 }
 stop_master() {
-    ssh -oControlPath="$SSH_CONTROL_PATH" -O exit "$USERATHOST" 2>/dev/null || :
+    ssh -oControlPath="$SSH_CONTROL_PATH" -O exit "$USERATHOST" 2>/dev/null ||
+        true
 }
-trap 'stop_master; rm -rf "$SSH_MUX_DIR"' EXIT INT TERM
+cleanup() {
+    stop_master
+    rm -rf "$SSH_MUX_DIR"
+}
+trap 'cleanup' EXIT
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
+
 
 while true; do
     ret=0

--- a/contrib/planb-double-backup
+++ b/contrib/planb-double-backup
@@ -37,6 +37,7 @@ trap 'cleanup; trap - TERM; kill -TERM $$' TERM
 
 
 while true; do
+    start_master
     ret=0
     DATASETS=$("$here/planb-double-backup-sources.py" "$USERATHOST") || ret=$?
 
@@ -61,7 +62,6 @@ while true; do
     echo '' $DATASETS
     echo
 
-    start_master
     "$here/manual-zfssync.sh" "$USERATHOST" "$DESTPOOL" $DATASETS
     stop_master
 

--- a/contrib/planb-double-backup
+++ b/contrib/planb-double-backup
@@ -9,6 +9,24 @@ RESTART_EVERY=${3:-0}
 test -z "$USERATHOST" -o -z "$DESTPOOL" &&
     echo "usage: $0 user@host destpool [restartsec]" >&2 && exit 1
 
+# Multiplexing ssh connections: one master TCP/login for the whole run, so the
+# many zfs-list/snapshot/send calls in manual-zfssync.sh don't require
+# separate logins (slow and log-spammy).
+# WARNING: Cannot contain spaces or awkward shell characters.
+SSH_MUX_DIR=$(mktemp -d "${TMPDIR:-/tmp}/planb-ssh.XXXXXX")
+SSH_CONTROL_PATH="$SSH_MUX_DIR/ctl"
+export SSH_CONTROL_PATH
+
+start_master() {
+    ssh -oLogLevel=error -oControlMaster=yes -oControlPath="$SSH_CONTROL_PATH" \
+        -oControlPersist=60 -oServerAliveInterval=60 -oServerAliveCountMax=3 \
+        -oBatchMode=yes -N -f "$USERATHOST"
+}
+stop_master() {
+    ssh -oControlPath="$SSH_CONTROL_PATH" -O exit "$USERATHOST" 2>/dev/null || :
+}
+trap 'stop_master; rm -rf "$SSH_MUX_DIR"' EXIT INT TERM
+
 while true; do
     ret=0
     DATASETS=$("$here/planb-double-backup-sources.py" "$USERATHOST") || ret=$?
@@ -34,7 +52,9 @@ while true; do
     echo '' $DATASETS
     echo
 
+    start_master
     "$here/manual-zfssync.sh" "$USERATHOST" "$DESTPOOL" $DATASETS
+    stop_master
 
     # The zfssync wipes this trigger. Re-set it.
     if test $ret -eq 2 -a -f /etc/zabbix/zabbix_agentd.conf; then

--- a/contrib/planb-double-backup-sources.py
+++ b/contrib/planb-double-backup-sources.py
@@ -5,6 +5,7 @@
 # Right now:
 # - assuming you're running this as root
 # - remote has planb access
+import os
 import sys
 
 from argparse import ArgumentParser
@@ -62,8 +63,14 @@ class DatasetStorage:
 
 
 def get_server_datasets(server):
+    ssh_opts = ['-oLogLevel=error']
+    if os.environ.get('SSH_CONTROL_PATH'):
+        ssh_opts.extend([
+            '-oControlMaster=no',
+            '-oControlPath={}'.format(os.environ['SSH_CONTROL_PATH']),
+        ])
     return check_output(
-        ['ssh', server, '-oLogLevel=error', 'planb', 'blist', '--double'],
+        ['ssh'] + ssh_opts + [server, 'planb', 'blist', '--double'],
         text=True).splitlines()
 
 

--- a/contrib/planb-zfssync.sh
+++ b/contrib/planb-zfssync.sh
@@ -101,6 +101,11 @@ if test "$contains" != "filesystems"; then
     sudo zfs set planb:contains=filesystems "$planb_storage_name"
 fi
 
+target_snapshot=$planb_snapshot_target
+target_snapshot_prefix=${planb_snapshot_target%-*}
+# XXX: do we?
+test "$target_snapshot_prefix" = "planb"  # (not needed, we use planb:owner)
+
 
 ssh_target="$1"; shift  # remotebackup@DEST (options like -luser disallowed)
 # XXX: todo: sanitize $1? (no spaces, no funny chars)
@@ -114,16 +119,19 @@ else
     ssh_options="$ssh_options -o StrictHostKeyChecking=no"
 fi
 
-target_snapshot=$planb_snapshot_target
-target_snapshot_prefix=${planb_snapshot_target%-*}
-# XXX: do we?
-test "$target_snapshot_prefix" = "planb"  # (not needed, we use planb:owner)
+# Multiplexing ssh connections: one master TCP/login for the whole run, so the
+# many zfs-list/snapshot/send calls below don't require separate logins (slow
+# and log-spammy).
+# WARNING: Cannot contain spaces or awkward shell characters. It's our
+# job to clean up ssh_mux_dir now.
+ssh_mux_dir=$(mktemp -d "${TMPDIR:-/tmp}/planb-ssh.XXXXXX")
+ssh_control_path="$ssh_mux_dir/ctl"
 
 # Prepare globals, so we know what to refactor
 ZFS_SEND_OPTION=$zfs_send_option
 ZFS_RECV_OPTION=$zfs_recv_option
 ZFS_RECURSIVE=$zfs_recursive
-SSH_OPTIONS=$ssh_options
+SSH_OPTIONS="$ssh_options -o ControlMaster=no -o ControlPath=$ssh_control_path"
 SSH_TARGET=$ssh_target
 TARGET_SNAPSHOT=$target_snapshot
 TARGET_SNAPSHOT_PREFIX=$target_snapshot_prefix
@@ -280,6 +288,14 @@ prune_remote_snapshots() {
     fi
 }
 
+
+# Start master ssh connection.
+trap 'ssh -o ControlPath="$ssh_control_path" -O exit "$ssh_target" \
+    2>/dev/null || :; rm -rf "$ssh_mux_dir"' EXIT
+ssh -o LogLevel=error $ssh_options \
+    -o ControlMaster=yes -o ControlPath=$ssh_control_path \
+    -o ControlPersist=60 -o ServerAliveInterval=60 -o ServerAliveCountMax=3 \
+    -o BatchMode=yes -N -f "$ssh_target"
 
 # Download snapshots (make them on remote if necessary).
 for arg in "$@"; do

--- a/contrib/planb-zfssync.sh
+++ b/contrib/planb-zfssync.sh
@@ -289,9 +289,15 @@ prune_remote_snapshots() {
 }
 
 
-# Start master ssh connection.
-trap 'ssh -o ControlPath="$ssh_control_path" -O exit "$ssh_target" \
-    2>/dev/null || :; rm -rf "$ssh_mux_dir"' EXIT
+# Setup cleanup handler and start master ssh connection.
+stop_ssh() {
+    ssh -o ControlPath="$ssh_control_path" -O exit "$ssh_target" 2>/dev/null \
+        || true
+    rm -rf "$ssh_mux_dir"
+}
+trap 'stop_ssh' EXIT
+trap 'stop_ssh; trap - INT; kill -INT $$' INT
+trap 'stop_ssh; trap - TERM; kill -TERM $$' TERM
 ssh -o LogLevel=error $ssh_options \
     -o ControlMaster=yes -o ControlPath=$ssh_control_path \
     -o ControlPersist=60 -o ServerAliveInterval=60 -o ServerAliveCountMax=3 \


### PR DESCRIPTION
Use a single ssh session for multiple data fetches. This should cut down on the login spam tremendously.

Change: osso-org/changes#3026